### PR TITLE
Update uselessItemRemovers.

### DIFF
--- a/Randomizers/FldItems.py
+++ b/Randomizers/FldItems.py
@@ -26,7 +26,7 @@ src = filenames.ev_script.value
 def uselessItemRemover(itemNo):
     if itemNo > 428: # Explorer Kit onwards
         return True
-    elif itemNo in [0, 70, 71]: # None, Master Ball, Safari Ball, Life Orb, Power Orb
+    elif itemNo in [0, 70, 71]: # None, Life Orb, Power Orb
         return True
     elif itemNo >= 65 and itemNo <= 69: # Blue Flute to White Flute
         return True

--- a/Randomizers/FldItems.py
+++ b/Randomizers/FldItems.py
@@ -24,24 +24,27 @@ outputModPath = paths.emulatorPath.value
 src = filenames.ev_script.value
 
 def uselessItemRemover(itemNo):
-    
-    if itemNo > 428: ##Explorer kit
+    if itemNo > 428: # Explorer Kit onwards
         return True
-    elif itemNo >= 159 and itemNo <= 212: #Figy Berry to Rowap Berry
+    elif itemNo in [0, 70, 71]: # None, Master Ball, Safari Ball, Life Orb, Power Orb
         return True
-    elif itemNo >= 137 and itemNo <= 148: #Grass mail to Brick mail
+    elif itemNo >= 65 and itemNo <= 69: # Blue Flute to White Flute
         return True
-    elif itemNo >= 113 and itemNo <= 134: #Braces and Arceus Plates
+    elif itemNo >= 95 and itemNo <= 98: # Growth Mulch to Gooey Mulch
         return True
-    elif itemNo in [236, 155, 70, 71]: #Light ball, Oran berry, Shoal Salt, and Shoal Shell
+    elif itemNo >= 112 and itemNo <= 134: # Griseous Orb to Sweet Heart
         return True
-    elif itemNo >= 95 and itemNo <= 98: #Mulches for Berry Planting
+    elif itemNo >= 137 and itemNo <= 148: # Greet Mail to Bridge Mail M
         return True
-    elif itemNo >= 256 and itemNo <= 264: #Lucky punch to Yellow scarf
+    elif itemNo == 155: # Oran Berry
         return True
-    elif itemNo == 216: #EXP Share
+    elif itemNo >= 159 and itemNo <= 212: # Figy Berry to Rowap Berry
         return True
-    elif itemNo in [0, 1, 5, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134]:
+    elif itemNo == 216: # Exp. Share
+        return True
+    elif itemNo == 236: # Light Ball
+        return True
+    elif itemNo >= 256 and itemNo <= 264: # Lucky Punch to Yellow Scarf
         return True
     else:
         return False

--- a/Randomizers/Shop.py
+++ b/Randomizers/Shop.py
@@ -23,35 +23,35 @@ outputModPath = paths.emulatorPath.value
 src = filenames.masterdatas.value
 
 def uselessItemRemover(itemNo):
-    
-    if itemNo > 428: ##Explorer kit
+    if itemNo > 428: # Explorer Kit onwards
         return True
-    elif itemNo >= 159 and itemNo <= 212: #Figy Berry to Rowap Berry
+    elif itemNo in [0, 1, 5, 70, 71]: # None, Master Ball, Safari Ball, Life Orb, Power Orb
         return True
-    elif itemNo >= 137 and itemNo <= 148: #Grass mail to Brick mail
+    elif itemNo >= 65 and itemNo <= 69: # Blue Flute to White Flute
         return True
-    elif itemNo >= 113 and itemNo <= 134: #Braces and unusable items
+    elif itemNo >= 95 and itemNo <= 98: # Growth Mulch to Gooey Mulch
         return True
-    elif itemNo in [236, 155, 70, 71]: #Light ball, Oran berry, Shoal Salt, and Shoal Shell
+    elif itemNo >= 112 and itemNo <= 134: # Griseous Orb to Sweet Heart
         return True
-    elif itemNo >= 95 and itemNo <= 98: #Mulches for Berry Planting
+    elif itemNo >= 137 and itemNo <= 148: # Greet Mail to Bridge Mail M
         return True
-    elif itemNo >= 256 and itemNo <= 264: #Lucky punch to Yellow scarf
+    elif itemNo == 155: # Oran Berry
         return True
-    elif itemNo == 216: #EXP Share
+    elif itemNo >= 159 and itemNo <= 212: # Figy Berry to Rowap Berry
         return True
-    elif itemNo in [0, 1, 5, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134]:
+    elif itemNo == 216: # Exp. Share
+        return True
+    elif itemNo == 236: # Light Ball
+        return True
+    elif itemNo >= 256 and itemNo <= 264: # Lucky Punch to Yellow Scarf
         return True
     else:
         return False
-    
+
 def generateRandom(amount):
     randomList = []
     lowRange = 1
     highRange = 327
-    
-    pokeballNo = random.randint(1, 15) ##Puts a pokeball in the first slot
-    randomList.append(pokeballNo)
     
     for i in range(amount - 1):
         itemNo = random.randrange(lowRange, highRange)

--- a/Randomizers/Shop.py
+++ b/Randomizers/Shop.py
@@ -90,8 +90,6 @@ def RandomizeShops(text, romFSPath):
                     itemList = generateRandom(len(tree[shop]))
                     i = 0
                     for item in tree[shop]:
-                        print("I = {}".format(i))
-                        print("itemList = {}".format(itemList))
                         item["ItemNo"] = itemList[i]
                         i += 1
             else:

--- a/Randomizers/Shop.py
+++ b/Randomizers/Shop.py
@@ -53,7 +53,7 @@ def generateRandom(amount):
     lowRange = 1
     highRange = 327
     
-    for i in range(amount - 1):
+    for i in range(amount):
         itemNo = random.randrange(lowRange, highRange)
         ##while item is useless generate a different item
         while uselessItemRemover(itemNo) or itemNo in randomList:
@@ -90,6 +90,8 @@ def RandomizeShops(text, romFSPath):
                     itemList = generateRandom(len(tree[shop]))
                     i = 0
                     for item in tree[shop]:
+                        print("I = {}".format(i))
+                        print("itemList = {}".format(itemList))
                         item["ItemNo"] = itemList[i]
                         i += 1
             else:


### PR DESCRIPTION
Continuing on #28, this implements some more changes to the randomizer's useless item removers:

- Add back 1 and 5 (Master Ball and Safari Ball) to field items as they can be used, just not bought from shops;
- Remove 65 to 69 (Blue Flute to White Flute) as they are broken items;
- Remove 112 (Griseous Orb) as it cannot be bought by moving it to the proper elif;
- Update item comments to be clearer about the items being removed;
- Cleanup item removal checks to be in order (kept 428 in front as it optimizes it a little in theory);
- Removes Pokéball always in first slot, reason being you get 20 regular balls from Lucas at the start anyway.
  Maybe consider making this an option instead?